### PR TITLE
Allow index file to not exist

### DIFF
--- a/index.js
+++ b/index.js
@@ -83,17 +83,16 @@ exports = module.exports = function pager(options){
 
     const pagesInfo = [...pageKeys].map((el, i) => ({ path: el, index: i+1, label: pageLabel.replace(/:PAGE/, i+1) }));
 
+    if(options.index && !files[options.index]) {
+      files[options.index] = files[pagePattern.replace(/:PAGE/, 1)]
+      pagesInfo[0].path = options.index;
+    }
+
     pagesInfo.forEach(function(el, i, all){
       files[el.path].pages = all;
       files[el.path].pagination.prev = i > 0 ? all[i-1].path : null;
       files[el.path].pagination.next = i < all.length-1 ? all[i+1].path : null;
     });
-
-    if (options.index && type(files[options.index]) == 'object'){
-      files[options.index].pagination = files[pagePattern.replace(/:PAGE/, 1)].pagination;
-      files[options.index].pages = pagesInfo;
-    }
-
 
     done();
 

--- a/index.js
+++ b/index.js
@@ -53,7 +53,7 @@ exports = module.exports = function pager(options){
 
       if(!pageKeys.has(pageDist)){
         pageKeys.add(pageDist);
-        files[pageDist] = {
+        files[pageDist] = Object.assign({}, files[pageDist], {
           canonical: pageDist,
           contents: template,
           layout: options.layoutName,
@@ -61,7 +61,7 @@ exports = module.exports = function pager(options){
             current: currentPage,
             files: []
           }
-        }
+        });
       }
 
       files[pageDist].pagination.files.push(post);

--- a/index.js
+++ b/index.js
@@ -32,13 +32,8 @@ exports = module.exports = function pager(options){
     const pagePattern = options.pagePattern || 'page/:PAGE/index.html';
     const elementsPerPage = options.elementsPerPage || 5;
     const pageLabel = options.pageLabel || ':PAGE';
-
-
     const metadata = metalsmith.metadata();
-
-
     const template = fs.readFileSync(path.join(metalsmith.source(), options.paginationTemplatePath));
-
 
     let groupedPosts;
 
@@ -49,20 +44,16 @@ exports = module.exports = function pager(options){
       throw new Error(`The collection ${options.collection} does not exist.`);
     }
 
-
-
     const pageKeys = new Set();
 
-    //
-    // enrich the metalsmith "files" collection with the pages
-    // which contain the "paginated list of pages"
-    groupedPosts.reduce(function(fileList, collectionEntry, index) {
+    groupedPosts.forEach(function(post, i){
 
-      const currentPage = Math.floor(index / elementsPerPage) + 1;
-      const pageDist = pagePattern.replace(/:PAGE/, currentPage);
+      const currentPage = Math.floor(i / elementsPerPage) + 1;
+      const pageDist = options.index && currentPage == 1 ? options.index : pagePattern.replace(/:PAGE/, currentPage);
 
-      if (fileList[pageDist] == null){
-        fileList[pageDist] = {
+      if(!pageKeys.has(pageDist)){
+        pageKeys.add(pageDist);
+        files[pageDist] = {
           canonical: pageDist,
           contents: template,
           layout: options.layoutName,
@@ -73,22 +64,11 @@ exports = module.exports = function pager(options){
         }
       }
 
-      pageKeys.add(pageDist);
-      fileList[pageDist].pagination.files.push(collectionEntry);
+      files[pageDist].pagination.files.push(post);
 
-      return fileList;
-
-    }, files);
-
+    });
 
     const pagesInfo = [...pageKeys].map((el, i) => ({ path: el, index: i+1, label: pageLabel.replace(/:PAGE/, i+1) }));
-
-    if (options.index){
-      if(!files[options.index]){
-        files[options.index] = files[pagePattern.replace(/:PAGE/, 1)];
-      }
-      pagesInfo[0].path = options.index;
-    }
 
     pagesInfo.forEach(function(el, i, all){
       files[el.path].pages = all;

--- a/index.js
+++ b/index.js
@@ -83,8 +83,8 @@ exports = module.exports = function pager(options){
 
     const pagesInfo = [...pageKeys].map((el, i) => ({ path: el, index: i+1, label: pageLabel.replace(/:PAGE/, i+1) }));
 
-    if(options.index) {
-      if(!files[options.index]) files[options.index] = files[pagePattern.replace(/:PAGE/, 1)]
+    if(options.index){
+      if(!files[options.index]) files[options.index] = files[pagePattern.replace(/:PAGE/, 1)];
       pagesInfo[0].path = options.index;
     }
 

--- a/index.js
+++ b/index.js
@@ -84,7 +84,9 @@ exports = module.exports = function pager(options){
     const pagesInfo = [...pageKeys].map((el, i) => ({ path: el, index: i+1, label: pageLabel.replace(/:PAGE/, i+1) }));
 
     if (options.index){
-      if(!files[options.index]) files[options.index] = files[pagePattern.replace(/:PAGE/, 1)];
+      if(!files[options.index]){
+        files[options.index] = files[pagePattern.replace(/:PAGE/, 1)];
+      }
       pagesInfo[0].path = options.index;
     }
 

--- a/index.js
+++ b/index.js
@@ -83,8 +83,8 @@ exports = module.exports = function pager(options){
 
     const pagesInfo = [...pageKeys].map((el, i) => ({ path: el, index: i+1, label: pageLabel.replace(/:PAGE/, i+1) }));
 
-    if(options.index && !files[options.index]) {
-      files[options.index] = files[pagePattern.replace(/:PAGE/, 1)]
+    if(options.index) {
+      if(!files[options.index]) files[options.index] = files[pagePattern.replace(/:PAGE/, 1)]
       pagesInfo[0].path = options.index;
     }
 

--- a/index.js
+++ b/index.js
@@ -83,7 +83,7 @@ exports = module.exports = function pager(options){
 
     const pagesInfo = [...pageKeys].map((el, i) => ({ path: el, index: i+1, label: pageLabel.replace(/:PAGE/, i+1) }));
 
-    if(options.index){
+    if (options.index){
       if(!files[options.index]) files[options.index] = files[pagePattern.replace(/:PAGE/, 1)];
       pagesInfo[0].path = options.index;
     }

--- a/tests/metalsmith-pager.js
+++ b/tests/metalsmith-pager.js
@@ -154,7 +154,7 @@ tape('the "pagination" property is populated with the paginated data (pagination
 tape('an index.html page is not created with obmission of the index property', function(t) {
 
   const options = {
-    collection: 'posts',
+    collection: 'pages',
     elementsPerPage: 3,
     pagePattern: ':PAGE/index.html',
     pageLabel: '<:PAGE>',
@@ -166,15 +166,7 @@ tape('an index.html page is not created with obmission of the index property', f
 
   const files = {
     '/post1': { collection: ['pages'], contents: new Buffer('Hello world!') },
-    '/post2': { collection: ['posts', 'pages'], contents: new Buffer('This is both a post both a page.') },
-    '/post3': { collection: ['pages', 'posts'], contents: new Buffer('This is both a page both a post. Strange.') },
-    '/post4': { collection: ['posts'], contents: new Buffer('Yeah, really strange!') },
-    '/post5': { collection: ['posts'], contents: new Buffer('Cool Stuff.') },
-    '/post6': { collection: ['posts'], contents: new Buffer('The sixth post.') },
-    '/post7': { collection: ['posts'], contents: new Buffer('Just another post.') },
-    '/post8': { collection: ['posts'], contents: new Buffer('Almost done here.') },
-    '/post9': { collection: [], contents: new Buffer('This is nothing.') },
-    '/post10': { collection: ['posts'], contents: new Buffer('Latest is a post! YAHOO.') },
+    '/post2': { collection: ['pages'], contents: new Buffer('This is both a post both a page.') },
   }
 
   const metalsmith = metalSmithFromFiles(files)

--- a/tests/metalsmith-pager.js
+++ b/tests/metalsmith-pager.js
@@ -148,26 +148,25 @@ tape('the "pagination" property is populated with the paginated data (pagination
   const doneSpy = sinon.spy();
 
   let readFileSync = sinon.stub(fs, 'readFileSync').returns('hbs contents');
+  let pages = ['boom.html', '2/index.html', '3/index.html'];
 
   pager(files, metalsmith, doneSpy);
 
-  t.ok(files.hasOwnProperty('1/index.html') && files.hasOwnProperty('2/index.html') && files.hasOwnProperty('3/index.html'), 'check props');
+  pages.forEach(function(page, i){
 
-  ['1/index.html', '2/index.html', '3/index.html'].forEach(function(prop, i) {
-    t.ok(files.hasOwnProperty(prop), 'check props');
+    t.ok(files.hasOwnProperty(page, 'check props'));
 
-    t.equal(files[prop].pages.length, 3, 'check number of pages');
-    t.equal(files[prop].pages.map(x => x.label)[i], '<'+(i+1)+'>', 'check page label');
+    t.equal(files[page].pages.length, pages.length, 'check number of pages');
+    t.equal(files[page].pages.map(x => x.label)[i], '<'+(i+1)+'>', 'check page label');
 
-    t.equal(files[prop].contents, 'hbs contents', 'check contents');
-    t.equal(files[prop].layout, 'archive.html', 'check layout');
+    t.equal(files[page].contents, 'hbs contents', 'check contents');
+    t.equal(files[page].layout, 'archive.html', 'check layout');
 
-    t.equal(files[prop].pagination.files.length, i<2 ? 3 : 2, 'check files per page (page '+prop+')');
 
+    t.equal(files[page].pagination.files.length, i<2 ? 3 : 2, 'check files per page (page '+page+')');
+    if(i > 0) t.equal(files[page].pagination.prev, pages[i-1], 'check previous');
+    if(i < 2) t.equal(files[page].pagination.next, pages[i+1], 'check next');
   });
-
-  t.deepEqual(files['boom.html'].pagination, files['1/index.html'].pagination, 'check index pagination');
-  t.deepEqual(files['boom.html'].pages, files['1/index.html'].pages, 'check index pagination links');
 
   t.ok(!files.hasOwnProperty('4/index.html'), 'check props missing');
 


### PR DESCRIPTION
This change fixes a few things:
- If you don't have an index file, it will simply use the existing `/pages/1/index.html` file contents. This allows you to just rename the first page to something like `/blog/index.html`.
- This makes the pagination point to the correct page when moving from page 2 to a renamed page 1. This was broken.